### PR TITLE
GetResponse() returns 0 when it need more data, not -1

### DIFF
--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -555,7 +555,7 @@ namespace System.Net
 				if (readState == ReadState.None) {
 					lineok = ReadLine (buffer, ref pos, max, ref line);
 					if (!lineok)
-						return -1;
+						return 0;
 
 					if (line == null) {
 						emptyFirstLine = true;
@@ -616,7 +616,7 @@ namespace System.Net
 					}
 
 					if (!finished)
-						return -1;
+						return 0;
 
 					foreach (string s in headers)
 						Data.Headers.SetInternal (s);


### PR DESCRIPTION
This merges in the support fix for Windows Server 2012

GetResponse() returns 0 to signal that it needs more data to complete
    while -1 signals an error processing the data.

@davidlanouette 
