### PR TITLE
Fix possible null value returned from GetContext

### DIFF
--- a/mcs/class/System/System.Net/HttpListener.cs
+++ b/mcs/class/System/System.Net/HttpListener.cs
@@ -261,18 +261,17 @@ namespace System.Net {
 			if (!listening)
 				throw new InvalidOperationException ("Please, call Start before using this method.");
 
-			while (listening) {
-				lock (ctx_queue) {
-					HttpListenerContext ctx = GetContextFromQueue ();
-					if (ctx != null) {
-						ctx.ParseAuthentication (SelectAuthenticationScheme (ctx));
-						return ctx;
-					}
-				}
-				Thread.Sleep(10);
+			HttpListenerContext ctx = null;
+			while (ctx == null) {
+				lock (ctx_queue)
+					ctx = GetContextFromQueue ();
+
+				if (ctx == null)
+					Thread.Sleep(10);
 			}
 
-			return null;
+			ctx.ParseAuthentication (SelectAuthenticationScheme (ctx));
+			return ctx;
 		}
 
 		public void Start ()


### PR DESCRIPTION
when stopping listener.

@amoiseev-softheme, that's a bit another way to fix the same problem of D-24329, but with our crutch of deadlocks.
