### PR TITLE
Throwing proper exception in case if listener has been stopped

### DIFF
--- a/mcs/class/System/System.Net/HttpListener.cs
+++ b/mcs/class/System/System.Net/HttpListener.cs
@@ -272,7 +272,7 @@ namespace System.Net {
 				Thread.Sleep(10);
 			}
 
-			return null;
+			throw new HttpListenerException (995, "The I/O operation has been aborted because of either a thread exit or an application request");
 		}
 
 		public void Start ()


### PR DESCRIPTION
in the middle of the GetContext call.

@amoiseev-softheme, this is proper fix of the D-24329, with our crutch of deadlocks.
